### PR TITLE
Merging pQTL results with Yoruba genotypes

### DIFF
--- a/pqtlPrepare.R
+++ b/pqtlPrepare.R
@@ -1,0 +1,44 @@
+
+library(readxl)
+library(R.utils)
+library(GenomicRanges)
+library(rtracklayer)
+library(VariantAnnotation)
+
+# Directory to save all data files produced by this script
+d <- "."
+
+# Download QTL results from Battle et al. 2014
+xls <- file.path(d, "1260793_DatafileS1.xlsx")
+if (!file.exists(xls)) {
+  download.file(url = "http://www.sciencemag.org/content/suppl/2014/12/17/science.1260793.DC1/1260793_DatafileS1.xlsx",
+                destfile = xls)
+}
+
+# Import pqtl data
+pqtl <- read_excel(xls, sheet = 4, col_names = TRUE)
+
+# Lift over from hg18 to hg19 coordinates
+chain_file <- file.path(d, "hg18ToHg19.over.chain.gz")
+if (!file.exists(chain_file)) {
+  download.file(url = "http://hgdownload.soe.ucsc.edu/goldenPath/hg18/liftOver/hg18ToHg19.over.chain.gz",
+                destfile = chain_file)
+}
+
+pqtl_hg18 <- pqtl
+colnames(pqtl_hg18)[6] <- "start"
+pqtl_hg18$end <- pqtl_hg18$start
+  
+pqtl_hg18 <- makeGRangesFromDataFrame(pqtl_hg18,
+                                      keep.extra.columns = TRUE,
+                                      ignore.strand = TRUE)
+
+chain <- import.chain(gunzip(chain_file, overwrite = TRUE))
+
+pqtl_hg19 <- liftOver(pqtl_hg18, chain)
+
+# Obtain the genotypes from the VCF files
+for (chr in 1:22) {
+  vcf_name <- paste0("snpeff/results/vcf/chr", chr, ".hg19.vcf")
+  file.exists(vcf_name)
+}

--- a/pqtlPrepare.R
+++ b/pqtlPrepare.R
@@ -3,7 +3,6 @@ library(readxl)
 library(R.utils)
 library(GenomicRanges)
 library(rtracklayer)
-library(VariantAnnotation)
 
 # Directory to save all data files produced by this script
 d <- "."
@@ -19,26 +18,36 @@ if (!file.exists(xls)) {
 pqtl <- read_excel(xls, sheet = 4, col_names = TRUE)
 
 # Lift over from hg18 to hg19 coordinates
-chain_file <- file.path(d, "hg18ToHg19.over.chain.gz")
+chain_file <- file.path(d, "hg18ToHg19.over.chain")
 if (!file.exists(chain_file)) {
+  chain_file_gz <- paste0(chain_file, ".gz")
   download.file(url = "http://hgdownload.soe.ucsc.edu/goldenPath/hg18/liftOver/hg18ToHg19.over.chain.gz",
-                destfile = chain_file)
+                destfile = chain_file_gz)
+  gunzip(chain_file_gz)
 }
 
 pqtl_hg18 <- pqtl
 colnames(pqtl_hg18)[6] <- "start"
 pqtl_hg18$end <- pqtl_hg18$start
-  
+
 pqtl_hg18 <- makeGRangesFromDataFrame(pqtl_hg18,
                                       keep.extra.columns = TRUE,
                                       ignore.strand = TRUE)
 
-chain <- import.chain(gunzip(chain_file, overwrite = TRUE))
+chain <- import.chain(chain_file)
 
 pqtl_hg19 <- liftOver(pqtl_hg18, chain)
+pqtl_hg19 <- as.data.frame(pqtl_hg19)
 
-# Obtain the genotypes from the VCF files
-for (chr in 1:22) {
-  vcf_name <- paste0("snpeff/results/vcf/chr", chr, ".hg19.vcf")
-  file.exists(vcf_name)
-}
+pqtl_final <- data.frame(ENSG = pqtl_hg19$ENSG,
+                         chr = pqtl_hg19$seqnames,
+                         perm.p.values = pqtl_hg19$perm.p.values,
+                         snp.pvalue = pqtl_hg19$snp.pvalue,
+                         snp.R.value = pqtl_hg19$snp.R.value,
+                         hg19.pos = pqtl_hg19$start)
+# Sort by chromosome (numeric) and position
+pqtl_final <- pqtl_final[order(as.numeric(sub("chr", "", pqtl_final$chr)),
+                               pqtl_final$hg19.pos), ]
+
+head(pqtl_final)
+write.table(pqtl_final, "pqtl-hg19.txt", quote = FALSE, sep = "\t", row.names = FALSE)

--- a/pqtlPrepare.py
+++ b/pqtlPrepare.py
@@ -7,13 +7,17 @@ pqtl_header = pqtl_file.readline()
 
 # Input the names of the samples. We need the genotypes for 18486, 18862, and
 # 19160.
-samples = open("/mnt/lustre/data/internal/genotypes/hg19/YRI/YRI_samples.txt", "r")
-
-samples.close()
+samples_file = open("/mnt/lustre/data/internal/genotypes/hg19/YRI/YRI_samples.txt", "r")
+samples = [s.strip().split()[0] for s in samples_file]
+samples_file.close()
 
 out_file = open("pqtl-genos.txt", "w")
 # Write header for output
-out_file.write(pqtl_header.strip())
+out_file.write(pqtl_header.strip() + "\t" + \
+               "#CHROM" + "\t" + "POS" + "\t" + "ID" + "\t" + \
+               "REF" + "\t" + "ALT" + "\t" + "QUAL" + "\t" + \
+               "FILTER" + "\t" + "INFO" + "\t" + "FORMAT" + "\t" + \
+               "\t".join(samples) + "\n")
 
 # Use a log file to investigate how the program is working
 log_file = open("pqtl-log.txt", "w")
@@ -35,16 +39,18 @@ for pqtl in pqtl_file:
         vcf_file = open("snpeff/results/vcf/" + chr + ".hg19.vcf", "r")
         chr_current = chr
         log_file.write("current\t" + chr_current + "\n")
-    # If the pQTL is the same as the previous one, i.e. it is associated with
-    # more than one gene, output the same SNP information instead of iterating
-    # through more SNPs. This could also happen if the previous SNP could not be found and
-    # the very next SNP that stopped the searching (because its position was
+    # If the pQTL is the same as the previous one, i.e. it is
+    # associated with more than one gene, output the same SNP
+    # information instead of iterating through more SNPs. This could
+    # also happen if the previous SNP could not be found and the very
+    # next SNP that stopped the searching (because its position was
     # greater than that being searched for) was a pQTL.
     if pos == vcf_pos:
         out_file.write(pqtl.strip() + "\t" + vcf)
         continue
-    # Search through the vcf file until the SNP is found. If the SNP position becomes
-    # less than the current SNP in the vcf file, stop searching and output NA.
+    # Search through the vcf file until the SNP is found. If the SNP
+    # position becomes less than the current SNP in the vcf file, stop
+    # searching and output NA.
     for vcf in vcf_file:
         if vcf[0] == "#":
             continue
@@ -55,7 +61,7 @@ for pqtl in pqtl_file:
             out_file.write(pqtl.strip() + "\t" + vcf)
             break
         elif pos < vcf_pos:
-            out_file.write(pqtl.strip() + "\t" + "NA" + "\n")
+            out_file.write(pqtl.strip() + "\tNA"*(9 + len(samples)) + "\n")
             break
 
 pqtl_file.close()

--- a/pqtlPrepare.py
+++ b/pqtlPrepare.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+# Input the pQTL information. They are sorted by chromosome and position.
+# This file was created by pqtlPrepare.R.
+pqtl_file = open("pqtl-hg19.txt", "r")
+pqtl_header = pqtl_file.readline()
+
+# Input the names of the samples. We need the genotypes for 18486, 18862, and
+# 19160.
+samples = open("/mnt/lustre/data/internal/genotypes/hg19/YRI/YRI_samples.txt", "r")
+
+samples.close()
+
+out_file = open("pqtl-genos.txt", "w")
+# Write header for output
+out_file.write(pqtl_header.strip())
+
+# Use a log file to investigate how the program is working
+log_file = open("pqtl-log.txt", "w")
+
+# Start searching on chr1
+chr_current = "chr1"
+vcf_file = open("snpeff/results/vcf/chr1.hg19.vcf", "r")
+vcf_pos = None
+log_file.write("current\t" + chr_current + "\n")
+
+for pqtl in pqtl_file:
+    pqtl_cols = pqtl.strip().split("\t")
+    chr = pqtl_cols[1]
+    pos = int(pqtl_cols[5])
+    log_file.write(chr + "\t" + str(pos) + "\n")
+    # If the pQTL is on the next chromosome, open its vcf file.
+    if chr != chr_current:
+        vcf_file.close()
+        vcf_file = open("snpeff/results/vcf/" + chr + ".hg19.vcf", "r")
+        chr_current = chr
+        log_file.write("current\t" + chr_current + "\n")
+    # If the pQTL is the same as the previous one, i.e. it is associated with
+    # more than one gene, output the same SNP information instead of iterating
+    # through more SNPs. This could also happen if the previous SNP could not be found and
+    # the very next SNP that stopped the searching (because its position was
+    # greater than that being searched for) was a pQTL.
+    if pos == vcf_pos:
+        out_file.write(pqtl.strip() + "\t" + vcf)
+        continue
+    # Search through the vcf file until the SNP is found. If the SNP position becomes
+    # less than the current SNP in the vcf file, stop searching and output NA.
+    for vcf in vcf_file:
+        if vcf[0] == "#":
+            continue
+        vcf_cols = vcf.strip().split("\t")
+        vcf_pos = int(vcf_cols[1])
+        log_file.write(str(vcf_pos) + "\n")
+        if pos == vcf_pos:
+            out_file.write(pqtl.strip() + "\t" + vcf)
+            break
+        elif pos < vcf_pos:
+            out_file.write(pqtl.strip() + "\t" + "NA" + "\n")
+            break
+
+pqtl_file.close()
+vcf_file.close()
+out_file.close()
+log_file.close()


### PR DESCRIPTION
This creates a file that is a combination of [Supplemental Data File 1 of Battle et al.](http://www.sciencemag.org/content/suppl/2014/12/17/science.1260793.DC1/1260793_DatafileS1.xlsx) and the imputed Yoruba genotypes.

Bryce re-ran the imputation a few weeks ago using new settings that resulted in more SNPs passing the filters. Thus I had to re-run the snpeff pipeline. The updated results are here:

/mnt/lustre/home/jdblischak/repos/Phospilot/snpeff/results/snpeff_final.txt

The new merged file is here:

/mnt/lustre/home/jdblischak/repos/Phospilot/pqtl-genos.txt

Of the 278 pQTLs, we do not have genotype information for 36 of them. This is due to the slightly different processing of the genotype data that was used for the pQTL study compared to this newer data.
